### PR TITLE
Enable auth support for 2.6 servers

### DIFF
--- a/rc.subr.2.6
+++ b/rc.subr.2.6
@@ -10,7 +10,7 @@ SERVER=${SERVER:-"$GAMEDIR/freeciv-server"}
 SAVEDIR=${SAVEDIR:-"$GAMEDIR/save"}
 FCDBCONF=${FCDBCONF:-"$HOME/server/lt-database-${FC_VERSION}.conf"}
 
-OPTIONS="-A none -p $PORT --saves $SAVEDIR --log $SAVEDIR/freeciv.log -r $GAMENAME.serv --meta -e -D $FCDBCONF"
+OPTIONS="-A none -p $PORT --saves $SAVEDIR --log $SAVEDIR/freeciv.log -r $GAMENAME.serv --meta -e -a -D $FCDBCONF"
 
 if [ "$1" ]; then
 	SAVE="$SAVEDIR/$1"


### PR DESCRIPTION
`-a` options was missing