### PR TITLE
Fix unit upkeep for big cities to match help text

### DIFF
--- a/LT57/data/LT57/effects.ruleset
+++ b/LT57/data/LT57/effects.ruleset
@@ -818,13 +818,13 @@ reqs   =
     }
 	
 	
-; Doubled for city size >= 8 - democracy will not get an extra unit at any size 
+; Doubled for city size >= 9 - democracy will not get an extra unit at any size 
 [effect_upkeep_free_mil_city_1]
 type    = "Make_Content_Mil"
 value   = 1
 reqs    =
     { "type", "name", "range", "present"
-      "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
       "Gov", "Anarchy", "Player", FALSE
       "Gov", "Tribal", "Player", FALSE
       "Gov", "Communism", "Player", FALSE
@@ -856,13 +856,13 @@ reqs   =
     }
 	
 	
-; Doubled for city size >= 8
+; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_2]
 type    = "Make_Content_Mil"
 value   = 2
 reqs    =
     { "type", "name", "range", "present"
-      "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
 ;      "Gov", "Anarchy", "Player", FALSE
 ;      "Gov", "Tribal", "Player", FALSE
       "Gov", "Communism", "Player", FALSE
@@ -893,13 +893,13 @@ reqs   =
 	
 	
 
-; Doubled for city size >= 8
+; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_3]
 type    = "Make_Content_Mil"
 value   = 3
 reqs    =
     { "type", "name", "range", "present"
-	  "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
       "Gov", "Anarchy", "Player", FALSE
       "Gov", "Tribal", "Player", FALSE
 ;      "Gov", "Communism", "Player", FALSE

--- a/LT57/data/LT57/effects.ruleset
+++ b/LT57/data/LT57/effects.ruleset
@@ -924,6 +924,8 @@ reqs    =
       "Gov", "Democracy", "Player"
     }
 
+
+; Free Gold/Shield unit upkeep for each city, depending on government
 [effect_upkeep_free_units_anarchy]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 2
@@ -960,6 +962,7 @@ reqs    =
       "OutputType", "Gold", "Local", FALSE
     }
 
+; 2 gold per unit, so 2 units free
 [effect_upkeep_free_units_fundamentalism]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 4
@@ -978,6 +981,7 @@ reqs    =
       "OutputType", "Shield", "Local", FALSE
     }
 
+; 2 gold per unit, so 1 unit free
 [effect_upkeep_free_units_democracy]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 2
@@ -987,6 +991,7 @@ reqs    =
       "OutputType", "Gold", "Local", FALSE
     }
 
+; 2 gold per unit, so 2 units free
 [effect_upkeep_free_units_federation]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 4
@@ -1005,6 +1010,104 @@ reqs    =
       "OutputType", "Shield", "Local", FALSE
     }
 
+
+; Free Gold/Shield unit upkeep -- doubled for big cities
+[effect_upkeep_free_units_anarchy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Anarchy", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_tribal_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Tribal", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_despotism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Despotism", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_monarchy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 3
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Monarchy", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 2 units free
+[effect_upkeep_free_units_fundamentalism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 4
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Fundamentalism", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_republic_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 1
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Republic", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 1 unit free
+[effect_upkeep_free_units_democracy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Democracy", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 2 units free
+[effect_upkeep_free_units_federation_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 4
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Federation", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_communism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 3
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Communism", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+
+
+; Food upkeep
 ; Any city can support up to four units...
 [effect_upkeep_free_units_food_base]
 type    = "Unit_Upkeep_Free_Per_City"

--- a/LT57/data/LT57/governments.ruleset
+++ b/LT57/data/LT57/governments.ruleset
@@ -91,9 +91,9 @@ _("\
  Conventional corruption increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 30%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -132,9 +132,9 @@ _("\
  increases with distance from the capital (half as fast with knowledge\
  of The Corporation).\n\
 * There is no base level of production waste, but an increasing amount\
- with distance from the capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ with distance from the capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -171,9 +171,9 @@ _("\
 * Base corruption is 20%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 10%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -210,10 +210,10 @@ _("\
 * Base corruption is 10%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 20%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -250,10 +250,10 @@ _("\
  will each force 2 unhappy citizens to become content (the maximum\
  possible).\n\
 * Base corruption is 30%, but is not affected by distance to the capital.\n\
-* There is no production waste.\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+* There is no production waste.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -299,10 +299,10 @@ _("\
 * Base corruption is 15%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 15%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -338,10 +338,10 @@ _("\
  governments). Knowledge of The Corporation eliminates this corruption.\n\
 * Base production waste is 30%, but is not affected by distance to the\
  capital.\n\
-* Has a senate that may prevent declaration of war.\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+* Has a senate that may prevent declaration of war.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -379,10 +379,10 @@ _("\
 * Base corruption is 25%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 5%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -419,11 +419,12 @@ _("\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 25%. This increases with distance from the\
  capital (half as fast with knowledge of Trade).\n\
-* Has a senate that may prevent declaration of war.\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- Unlike with many other governments the number of units avoiding the military unhappiness will NOT be doubled at this size.\
-")
+* Has a senate that may prevent declaration of war.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  Unlike with other governments, the number of units avoiding the military unhappiness will NOT be doubled at this size.\n\
+
+ ")
 
 ; /* <-- avoid gettext warnings
 ;

--- a/LTT/data/LTT/effects.ruleset
+++ b/LTT/data/LTT/effects.ruleset
@@ -818,13 +818,13 @@ reqs   =
     }
 	
 	
-; Doubled for city size >= 8 - democracy will not get an extra unit at any size 
+; Doubled for city size >= 9 - democracy will not get an extra unit at any size 
 [effect_upkeep_free_mil_city_1]
 type    = "Make_Content_Mil"
 value   = 1
 reqs    =
     { "type", "name", "range", "present"
-      "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
       "Gov", "Anarchy", "Player", FALSE
       "Gov", "Tribal", "Player", FALSE
       "Gov", "Communism", "Player", FALSE
@@ -856,13 +856,13 @@ reqs   =
     }
 	
 	
-; Doubled for city size >= 8
+; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_2]
 type    = "Make_Content_Mil"
 value   = 2
 reqs    =
     { "type", "name", "range", "present"
-      "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
 ;      "Gov", "Anarchy", "Player", FALSE
 ;      "Gov", "Tribal", "Player", FALSE
       "Gov", "Communism", "Player", FALSE
@@ -893,13 +893,13 @@ reqs   =
 	
 	
 
-; Doubled for city size >= 8
+; Doubled for city size >= 9
 [effect_upkeep_free_mil_city_3]
 type    = "Make_Content_Mil"
 value   = 3
 reqs    =
     { "type", "name", "range", "present"
-	  "MinSize", "8", "City", TRUE
+      "MinSize", "9", "City", TRUE
       "Gov", "Anarchy", "Player", FALSE
       "Gov", "Tribal", "Player", FALSE
 ;      "Gov", "Communism", "Player", FALSE

--- a/LTT/data/LTT/effects.ruleset
+++ b/LTT/data/LTT/effects.ruleset
@@ -924,6 +924,8 @@ reqs    =
       "Gov", "Democracy", "Player"
     }
 
+
+; Free Gold/Shield unit upkeep for each city, depending on government
 [effect_upkeep_free_units_anarchy]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 2
@@ -960,6 +962,7 @@ reqs    =
       "OutputType", "Gold", "Local", FALSE
     }
 
+; 2 gold per unit, so 2 units free
 [effect_upkeep_free_units_fundamentalism]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 4
@@ -978,6 +981,7 @@ reqs    =
       "OutputType", "Shield", "Local", FALSE
     }
 
+; 2 gold per unit, so 1 unit free
 [effect_upkeep_free_units_democracy]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 2
@@ -987,6 +991,7 @@ reqs    =
       "OutputType", "Gold", "Local", FALSE
     }
 
+; 2 gold per unit, so 2 units free
 [effect_upkeep_free_units_federation]
 type    = "Unit_Upkeep_Free_Per_City"
 value   = 4
@@ -1005,6 +1010,104 @@ reqs    =
       "OutputType", "Shield", "Local", FALSE
     }
 
+
+; Free Gold/Shield unit upkeep -- doubled for big cities
+[effect_upkeep_free_units_anarchy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Anarchy", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_tribal_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Tribal", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_despotism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Despotism", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_monarchy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 3
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Monarchy", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 2 units free
+[effect_upkeep_free_units_fundamentalism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 4
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Fundamentalism", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_republic_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 1
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Republic", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 1 unit free
+[effect_upkeep_free_units_democracy_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 2
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Democracy", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+; 2 gold per unit, so 2 units free
+[effect_upkeep_free_units_federation_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 4
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Federation", "Player", TRUE
+      "OutputType", "Gold", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+[effect_upkeep_free_units_communism_city]
+type    = "Unit_Upkeep_Free_Per_City"
+value   = 3
+reqs    =
+    { "type", "name", "range", "quiet"
+      "Gov", "Communism", "Player", TRUE
+      "OutputType", "Shield", "Local", FALSE
+      "MinSize", "9", "City", FALSE
+    }
+
+
+
+; Food upkeep
 ; Any city can support up to four units...
 [effect_upkeep_free_units_food_base]
 type    = "Unit_Upkeep_Free_Per_City"

--- a/LTT/data/LTT/governments.ruleset
+++ b/LTT/data/LTT/governments.ruleset
@@ -91,9 +91,9 @@ _("\
  Conventional corruption increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 30%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -132,9 +132,9 @@ _("\
  increases with distance from the capital (half as fast with knowledge\
  of The Corporation).\n\
 * There is no base level of production waste, but an increasing amount\
- with distance from the capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ with distance from the capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -171,9 +171,9 @@ _("\
 * Base corruption is 20%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 10%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks. \
- The number of free units will be doubled for cities with size of 9 or more.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -210,10 +210,10 @@ _("\
 * Base corruption is 10%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 20%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -250,10 +250,10 @@ _("\
  will each force 2 unhappy citizens to become content (the maximum\
  possible).\n\
 * Base corruption is 30%, but is not affected by distance to the capital.\n\
-* There is no production waste.\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+* There is no production waste.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -299,10 +299,10 @@ _("\
 * Base corruption is 15%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 15%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -338,10 +338,10 @@ _("\
  governments). Knowledge of The Corporation eliminates this corruption.\n\
 * Base production waste is 30%, but is not affected by distance to the\
  capital.\n\
-* Has a senate that may prevent declaration of war.\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+* Has a senate that may prevent declaration of war.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -379,10 +379,10 @@ _("\
 * Base corruption is 25%. This increases with distance from the capital\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 5%. This increases with distance from the\
- capital (half as fast with knowledge of Trade).\
- * The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- The number of units avoiding the military unhappiness will also double at this size.\
+ capital (half as fast with knowledge of Trade).\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  The number of units avoiding the military unhappiness will also double at this size.\n\
 ")
 
 ;------------------------------------------------------------------------
@@ -419,11 +419,12 @@ _("\
  (half as fast with knowledge of The Corporation).\n\
 * Base production waste is 25%. This increases with distance from the\
  capital (half as fast with knowledge of Trade).\n\
-* Has a senate that may prevent declaration of war.\
-* The big cities with size of 9 or more will get an extra 50% defense against miliary attacks.\
- The number of free units will be doubled for cities with size of 9 or more.\
- Unlike with many other governments the number of units avoiding the military unhappiness will NOT be doubled at this size.\
-")
+* Has a senate that may prevent declaration of war.\n\
+* Big cities with size of 9 or more will get an extra 50 % defense against military attacks. \n\
+* The number of free units will be doubled for cities with size of 9 or more.\
+  Unlike with other governments, the number of units avoiding the military unhappiness will NOT be doubled at this size.\n\
+
+ ")
 
 ; /* <-- avoid gettext warnings
 ;


### PR DESCRIPTION
Fix big city bonuses to match help text. Fix a missing newline in the help text.